### PR TITLE
 Pipe expression learned to handle `null` values.

### DIFF
--- a/tests/pipe.json
+++ b/tests/pipe.json
@@ -126,6 +126,10 @@
     {
       "expression": "foo[*].bar[*] | [0][0]",
       "result": {"baz": "one"}
+    },
+    {
+      "expression": "`null` | [@]",
+      "result": [ null ]
     }
   ]
 }]


### PR DESCRIPTION
Fixes #4.
See: https://github.com/jmespath/jmespath.py/pull/292