### PR TITLE
Report consistent error types.

### DIFF
--- a/tests/functions_strings.json
+++ b/tests/functions_strings.json
@@ -24,10 +24,10 @@
       },
       {
         "expression": "find_first(string, 'string', `1.3`, '2')",
-        "error": "invalid-value"
+        "error": "invalid-type"
       },
       {
-        "expression": "find_first(string, 'string', `1`, '2.4')",
+        "expression": "find_first(string, 'string', `1.3`, `2.4`)",
         "error": "invalid-value"
       },
 
@@ -101,12 +101,12 @@
 
       {
         "expression": "pad_left('string', '1')",
-        "error": "syntax"
+        "error": "invalid-type"
 
       },
       {
         "expression": "pad_left('string', `1`, '--')",
-        "error": "syntax"
+        "error": "invalid-value"
 
       },
       {


### PR DESCRIPTION
JEP-14 introduced a new `invalid-value` error type.

This begs the question whether priorities must be applied when checking error types.
For instance, the expression:

`` find_first('subject string', 'search', `1.3`, '2') ``

has two incorrect arguments.
The first one `` `1.3` `` is not a valid integer and should yield `invalid-value`.
The second one, `` '2' `` is not even a number, and should yield `invalid-type`.

Implementations are free to report errors any time, during parsing or at runtime.

It seems an intuitive behaviour, however, is to:

- First check the type for all input arguments. Most implementations will apply type-checking even before attempting to evaluate the function.
- Then check the valid set of values within the proper typed-arguments.

Which means that `invalid-type` would be returned first and then, if all types are consistent, `invalid-value` potentially.

Should we standardize this behaviour?
Should we attempt to precisely detect error types in compliance tests?