### PR TITLE
test: verify let expression identifier resolution precedence

### DIFF
--- a/tests/letexpr.json
+++ b/tests/letexpr.json
@@ -243,5 +243,17 @@
     "error": "syntax"
    }
   ]
+ },
+ {
+   "given": {
+     "foo": "outer"
+   },
+   "cases": [
+     {
+       "comment": "Inner scope explicitly sets 'foo' to null, should not fall back to outer scope",
+       "expression": "let $foo = foo in let $foo = null in $foo",
+       "result": null
+     }
+   ]
  }
 ]


### PR DESCRIPTION
Adds test to confirm identifier resolution rules from [JEP-011](https://github.com/jmespath-community/jmespath.spec/blob/main/jep-011-let-function.md), specifically verifying that inner scope values (including null) take precedence over outer scope values without falling back to parent scopes.

- https://github.com/jmespath-community/go-jmespath @6eb5a34 passes
- https://github.com/jmespath-community/typescript-jmespath @90c6ea4 fails

I have a [branch](https://github.com/jmespath-community/typescript-jmespath/compare/fix-scope-null-handling) with a proposed fix if this is the desired behavior.

<!-- ps-id: 1f0da73f-cdb3-496a-8e23-06626d25bb4b -->